### PR TITLE
Add 4k remaster version to blocked video IDs

### DIFF
--- a/AntiRickRoll/background.js
+++ b/AntiRickRoll/background.js
@@ -4,7 +4,8 @@
         "-51AfyMqnpI",
         "oHg5SJYRHA0",
         "cvh0nX08nRw",
-        "V-_O7nl0Ii0"
+        "V-_O7nl0Ii0",
+        "2ocykBzWDiM"
     ];
 
     if(blocked_ids.find(i => location.href.includes(i))) {


### PR DESCRIPTION
Added the 4k remaster version from https://www.youtube.com/watch?v=2ocykBzWDiM to the blocked IDs

(also I already messed up the GitHub ID history by renaming that branch haha)